### PR TITLE
Adding command line and auth support

### DIFF
--- a/cmd/fli/main.go
+++ b/cmd/fli/main.go
@@ -2,21 +2,34 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
-
 	"strings"
 
-	"errors"
+	"flag"
 
 	"github.com/sneakybueno/fli/fuego"
 )
 
-var fStore *fuego.FStore
-
 func main() {
-	firebaseURL := "https://go-fli.firebaseio.com/"
-	fStore = fuego.NewFStore(firebaseURL)
+	var firebaseURL string
+	var serviceAccountPath string
+
+	flag.StringVar(&firebaseURL, "host", "", "Firebase database URL (Required)")
+	flag.StringVar(&serviceAccountPath, "config", "", "Path to service account file (Required)")
+	flag.Parse()
+
+	if firebaseURL == "" || serviceAccountPath == "" {
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	fStore, err := fuego.NewFStore(firebaseURL, serviceAccountPath)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	fmt.Printf("Time to fli @ %s\n", fStore.WorkingDirectoryURL())
 	fmt.Print(fStore.Prompt())
@@ -25,7 +38,7 @@ func main() {
 	for scanner.Scan() {
 		input := scanner.Text()
 
-		m, err := processInput(input)
+		m, err := processInput(fStore, input)
 		if err != nil {
 			fmt.Println(err)
 		} else if m != "" {
@@ -36,7 +49,7 @@ func main() {
 	}
 }
 
-func processInput(input string) (string, error) {
+func processInput(fStore *fuego.FStore, input string) (string, error) {
 	if len(input) == 0 {
 		return "", nil
 	}
@@ -57,8 +70,7 @@ func processInput(input string) (string, error) {
 	case "ls":
 		return fStore.Ls()
 	case "pwd":
-		m := fmt.Sprintf("%s", fStore.WorkingDirectoryURL())
-		return m, nil
+		return fStore.WorkingDirectoryURL(), nil
 	default:
 		message := fmt.Sprintf("command not found: %s", command)
 		return "", fliError(message)

--- a/fuego/fuego.go
+++ b/fuego/fuego.go
@@ -1,21 +1,40 @@
 package fuego
 
 import (
-	"net/http"
-	"time"
+	"io/ioutil"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/google"
 )
 
 const (
-	fStoreDefaultTimeout = 60
+	firebaseDatabaseScope = "https://www.googleapis.com/auth/firebase.database"
+	firebaseUserInfoScope = "https://www.googleapis.com/auth/userinfo.email"
 )
 
-func NewFStore(firebaseURL string) *FStore {
-	client := &http.Client{
-		Timeout: time.Second * fStoreDefaultTimeout,
+// NewFStore builds a new store based on the 2 passed in params.
+// Attempts to read the file from serviceAccountPath and parse it
+// into a jwt.Config struct which provides an authorized http client.
+// No validation is done to ensure a valid firebaseURL or a valid
+// service account.
+func NewFStore(firebaseURL string, serviceAccountPath string) (*FStore, error) {
+	serviceAccountBytes, err := ioutil.ReadFile(serviceAccountPath)
+	if err != nil {
+		return nil, err
 	}
 
-	return &FStore{
+	jwtConfig, err := google.JWTConfigFromJSON(serviceAccountBytes, firebaseDatabaseScope, firebaseUserInfoScope)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.TODO()
+	client := jwtConfig.Client(ctx)
+
+	fStore := &FStore{
 		client:      client,
 		FirebaseURL: firebaseURL,
 	}
+
+	return fStore, nil
 }


### PR DESCRIPTION
Resolves #2 and added command line flags for configuration.

Flags:
-host: firebase URL
-config: path to serviceAccounts.json file downloaded from firebase

Only thing I am not sure about is 
`ctx := context.TODO()`

It works for now but we should look into this a bit more.