### PR TITLE
Open in browser

### DIFF
--- a/cmd/fli/main.go
+++ b/cmd/fli/main.go
@@ -67,6 +67,9 @@ func processInput(fStore *fuego.FStore, input string) (string, error) {
 		}
 		fStore.Cd(dir)
 		return "", nil
+	case "exit":
+		os.Exit(0)
+		return "", nil
 	case "ls":
 		return fStore.Ls()
 	case "pwd":

--- a/cmd/fli/main.go
+++ b/cmd/fli/main.go
@@ -9,6 +9,7 @@ import (
 
 	"flag"
 
+	"github.com/skratchdot/open-golang/open"
 	"github.com/sneakybueno/fli/fuego"
 )
 
@@ -79,7 +80,12 @@ func processInput(fStore *fuego.FStore, input string) (string, error) {
 		}
 
 		p := components[1]
-		return fStore.FirebaseURLFromWorkingDirectory(p), nil
+
+		url := fStore.FirebaseURLFromWorkingDirectory(p)
+		open.Start(url)
+
+		message := fmt.Sprintf("opening (%s) in default browser", url)
+		return message, nil
 	case "pwd":
 		return fStore.FirebaseURLFromWorkingDirectory("."), nil
 	default:

--- a/cmd/fli/main.go
+++ b/cmd/fli/main.go
@@ -31,7 +31,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Time to fli @ %s\n", fStore.WorkingDirectoryURL())
+	fmt.Printf("Time to fli @ %s\n", fStore.FirebaseURL)
 	fmt.Print(fStore.Prompt())
 
 	scanner := bufio.NewScanner(os.Stdin)
@@ -72,8 +72,16 @@ func processInput(fStore *fuego.FStore, input string) (string, error) {
 		return "", nil
 	case "ls":
 		return fStore.Ls()
+	case "open":
+		if len(components) != 2 {
+			message := fmt.Sprintf("Usage: open [path]")
+			return "", fliError(message)
+		}
+
+		p := components[1]
+		return fStore.FirebaseURLFromWorkingDirectory(p), nil
 	case "pwd":
-		return fStore.WorkingDirectoryURL(), nil
+		return fStore.FirebaseURLFromWorkingDirectory("."), nil
 	default:
 		message := fmt.Sprintf("command not found: %s", command)
 		return "", fliError(message)

--- a/fuego/fstore.go
+++ b/fuego/fstore.go
@@ -36,6 +36,53 @@ func NewFStore(firebaseURL string, serviceAccountPath string) (*FStore, error) {
 // FStore Directory Commands
 // ----------------------------------------------------------------------------
 
+// Prompt retuns a string to be displayed
+// as a prompt to the user
+func (fs *FStore) Prompt() string {
+	return "~/" + fs.BuildWorkingDirectoryPath(".") + " > "
+}
+
+// Wd (Working directory) returns the path for the "directory"
+// the FStore is currently in.
+func (fs *FStore) Wd() string {
+	return fs.BuildWorkingDirectoryPath(".")
+}
+
+// FirebaseURLFromWorkingDirectory builds the firebase URL
+// relative to the working directory. See BuildWorkingDirectoryPath
+// for more info on how the path is built.
+// Pass "" or "." to return the URL of the current working directory
+func (fs *FStore) FirebaseURLFromWorkingDirectory(path string) string {
+	return fs.FirebaseURL + fs.BuildWorkingDirectoryPath(path)
+}
+
+// BuildWorkingDirectoryPath builds the relative path
+// based on the current working directory.
+// Example: if the cwd = "/users" and path = "1234",
+// it will return users/1234
+// Pass "" or "." to return working directory path
+func (fs *FStore) BuildWorkingDirectoryPath(p string) string {
+	if p == "" || p == "." {
+		return path.Join(fs.workingDirectory...)
+	}
+
+	wd := fs.workingDirectory[:]
+
+	components := strings.Split(p, "/")
+	for _, component := range components {
+		if component == ".." {
+			length := len(wd)
+			if length > 0 {
+				wd = wd[:length-1]
+			}
+		} else {
+			wd = append(wd, component)
+		}
+	}
+
+	return path.Join(wd...)
+}
+
 // Cd (Change directory) emulates the cd command on a
 // terminal. One major difference, the Cd command will never fail
 // since firebase is a JSON store and not an actual directory
@@ -59,24 +106,6 @@ func (fs *FStore) Cd(dir string) {
 			fs.workingDirectory = append(fs.workingDirectory, component)
 		}
 	}
-}
-
-// Prompt retuns a string to be displayed
-// as a prompt to the user
-func (fs *FStore) Prompt() string {
-	return "~/" + fs.Wd() + " > "
-}
-
-// Wd (Working directory) returns the path for the "directory"
-// the FStore is currently in.
-func (fs *FStore) Wd() string {
-	return path.Join(fs.workingDirectory...)
-}
-
-// WorkingDirectoryURL returns the firebase URL
-// for the current working directory
-func (fs *FStore) WorkingDirectoryURL() string {
-	return fs.FirebaseURL + fs.Wd()
 }
 
 // Ls does a thing


### PR DESCRIPTION
Added the ability to open a given firebase path in a users default browser via a third party package.

Refactored URL and path building methods, I think they are a bit cleaner and easier to understand now.

Also added the exit command for clean exits. 

@flapjack103 Can you test on your local box before merging this in?